### PR TITLE
Fix nested redundant include for int128.h

### DIFF
--- a/absl/numeric/int128.h
+++ b/absl/numeric/int128.h
@@ -1151,14 +1151,14 @@ constexpr int64_t BitCastToSigned(uint64_t v) {
 
 }  // namespace int128_internal
 
-#if defined(ABSL_HAVE_INTRINSIC_INT128)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmodules-import-nested-redundant"
+#if defined(ABSL_HAVE_INTRINSIC_INT128)
 #include "absl/numeric/int128_have_intrinsic.inc"  // IWYU pragma: export
-#pragma clang diagnostic pop
 #else  // ABSL_HAVE_INTRINSIC_INT128
 #include "absl/numeric/int128_no_intrinsic.inc"  // IWYU pragma: export
 #endif  // ABSL_HAVE_INTRINSIC_INT128
+#pragma clang diagnostic pop
 
 ABSL_NAMESPACE_END
 }  // namespace absl


### PR DESCRIPTION
Moving up clang warning ignore to include both macro condition for ABSL_HAVE_INTRINSIC_INT128. Fix break break as seen from   https://github.com/firebase/firebase-ios-sdk/runs/5631123551?check_suite_focus=true  


@paulb777  @wu-hui