### PR TITLE
Suppress clang-tidy diagnostics for forward moving ref

### DIFF
--- a/absl/strings/str_split.h
+++ b/absl/strings/str_split.h
@@ -513,8 +513,10 @@ strings_internal::Splitter<
 StrSplit(StringType&& text, Delimiter d) {
   using DelimiterType =
       typename strings_internal::SelectDelimiter<Delimiter>::type;
+  // NOLINTBEGIN(bugprone-move-forwarding-reference)
   return strings_internal::Splitter<DelimiterType, AllowEmpty, std::string>(
       std::move(text), DelimiterType(d), AllowEmpty());
+  // NOLINTEND
 }
 
 template <typename Delimiter, typename Predicate>
@@ -538,8 +540,10 @@ strings_internal::Splitter<
 StrSplit(StringType&& text, Delimiter d, Predicate p) {
   using DelimiterType =
       typename strings_internal::SelectDelimiter<Delimiter>::type;
+  // NOLINTBEGIN(bugprone-move-forwarding-reference)
   return strings_internal::Splitter<DelimiterType, Predicate, std::string>(
       std::move(text), DelimiterType(d), std::move(p));
+  // NOLINTEND
 }
 
 ABSL_NAMESPACE_END


### PR DESCRIPTION
Suppress clang-tidy warning [bugprone-move-forwarding-reference](https://clang.llvm.org/extra/clang-tidy/checks/bugprone-move-forwarding-reference.html) as this appears to be coming from str_split.h internal build itself when clang-tidy diangnostics are turned on. 

```shell
 -> FirebaseFirestore (8.15.0)
    - WARN  | compiler_flags: Warnings must not be disabled(`-Wno compiler` flags).
    - ERROR | [iOS] build_pod: Static Analysis failed. You can use `--verbose` for more information. You can use `--no-clean` to save a reproducible buid environment.
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | xcodebuild:  note: Build preparation complete
    - NOTE  | [iOS] xcodebuild:  note: Planning
    - NOTE  | [iOS] xcodebuild:  note: Building targets in dependency order
    - NOTE  | [iOS] xcodebuild:  warning: Capabilities for Signing & Capabilities may not function correctly because its entitlements use a placeholder team ID. To resolve this, select a development team in the App editor. (in target 'App' from project 'App')
    - WARN  | xcodebuild:  /Users/runner/Library/Developer/Xcode/DerivedData/App-blajiudtslxcsseicvwfvotexenp/Build/Products/Release-iphonesimulator/abseil/absl.framework/Headers/strings/str_split.h:517:7: warning: Forwarding reference passed to std::move(), which may unexpectedly cause lvalues to be moved; use std::forward() instead [bugprone-move-forwarding-reference]
    - WARN  | xcodebuild:  /Users/runner/Library/Developer/Xcode/DerivedData/App-blajiudtslxcsseicvwfvotexenp/Build/Products/Release-iphonesimulator/abseil/absl.framework/Headers/strings/str_split.h:542:7: warning: Forwarding reference passed to std::move(), which may unexpectedly cause lvalues to be moved; use std::forward() instead [bugprone-move-forwarding-reference]
    - NOTE  | [iOS] xcodebuild:  Pods.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.2.99. (in target 'leveldb-library' from project 'Pods')

[!] FirebaseFirestore did not pass validation, due to 1 error.
```