### PR TITLE
32bit conversion warning fix for abseil cpp

### DIFF
--- a/absl/base/internal/sysinfo.cc
+++ b/absl/base/internal/sysinfo.cc
@@ -430,7 +430,7 @@ static constexpr int kBitsPerWord = 32;  // tid_array is uint32_t.
 // Returns the TID to tid_array.
 static void FreeTID(void *v) {
   intptr_t tid = reinterpret_cast<intptr_t>(v);
-  int word = tid / kBitsPerWord;
+  int word = (int)(tid / kBitsPerWord);
   uint32_t mask = ~(1u << (tid % kBitsPerWord));
   absl::base_internal::SpinLockHolder lock(&tid_lock);
   assert(0 <= word && static_cast<size_t>(word) < tid_array->size());
@@ -456,7 +456,7 @@ pid_t GetTID() {
 
   intptr_t tid = reinterpret_cast<intptr_t>(pthread_getspecific(tid_key));
   if (tid != 0) {
-    return tid;
+    return (pid_t)tid;
   }
 
   int bit;  // tid_array[word] = 1u << bit;

--- a/absl/debugging/failure_signal_handler.cc
+++ b/absl/debugging/failure_signal_handler.cc
@@ -326,7 +326,7 @@ static void AbslFailureSignalHandler(int signo, siginfo_t*, void* ucontext) {
   const GetTidType this_tid = absl::base_internal::GetTID();
   GetTidType previous_failed_tid = 0;
   if (!failed_tid.compare_exchange_strong(
-          previous_failed_tid, static_cast<intptr_t>(this_tid),
+          previous_failed_tid, static_cast<int>(this_tid),
           std::memory_order_acq_rel, std::memory_order_relaxed)) {
     ABSL_RAW_LOG(
         ERROR,

--- a/absl/debugging/internal/demangle.cc
+++ b/absl/debugging/internal/demangle.cc
@@ -456,7 +456,7 @@ static bool MaybeAppendDecimal(State *state, unsigned int val) {
     } while (p > buf && val != 0);
 
     // 'p' landed on the last character we set.  How convenient.
-    Append(state, p, kMaxLength - (p - buf));
+    Append(state, p, (int)(kMaxLength - (p - buf)));
   }
 
   return true;
@@ -466,7 +466,7 @@ static bool MaybeAppendDecimal(State *state, unsigned int val) {
 // Returns true so that it can be placed in "if" conditions.
 static bool MaybeAppend(State *state, const char *const str) {
   if (state->parse_state.append) {
-    int length = StrLen(str);
+    int length = (int)StrLen(str);
     MaybeAppendWithLength(state, str, length);
   }
   return true;
@@ -853,7 +853,7 @@ static bool ParseNumber(State *state, int *number_out) {
     state->parse_state.mangled_idx += p - RemainingInput(state);
     if (number_out != nullptr) {
       // Note: possibly truncate "number".
-      *number_out = number;
+      *number_out = (int)number;
     }
     return true;
   }

--- a/absl/flags/internal/flag.cc
+++ b/absl/flags/internal/flag.cc
@@ -483,7 +483,7 @@ bool FlagImpl::ReadOneBool() const {
 }
 
 void FlagImpl::ReadSequenceLockedData(void* dst) const {
-  int size = Sizeof(op_);
+  int size = (int)Sizeof(op_);
   // Attempt to read using the sequence lock.
   if (ABSL_PREDICT_TRUE(seq_lock_.TryRead(dst, AtomicBufferValue(), size))) {
     return;

--- a/absl/flags/parse.cc
+++ b/absl/flags/parse.cc
@@ -159,7 +159,7 @@ class ArgsList {
   // Returns success status: true if parsing successful, false otherwise.
   bool ReadFromFlagfile(const std::string& flag_file_name);
 
-  int Size() const { return args_.size() - next_arg_; }
+  int Size() const { return (int)(args_.size() - next_arg_); }
   int FrontIndex() const { return next_arg_; }
   absl::string_view Front() const { return args_[next_arg_]; }
   void PopFront() { next_arg_++; }

--- a/absl/hash/internal/city.cc
+++ b/absl/hash/internal/city.cc
@@ -97,7 +97,7 @@ static uint32_t Hash32Len13to24(const char *s, size_t len) {
   uint32_t d = Fetch32(s + (len >> 1));
   uint32_t e = Fetch32(s);
   uint32_t f = Fetch32(s + len - 4);
-  uint32_t h = len;
+  uint32_t h = (uint32_t)len;
 
   return fmix(Mur(f, Mur(e, Mur(d, Mur(c, Mur(b, Mur(a, h)))))));
 }
@@ -110,11 +110,11 @@ static uint32_t Hash32Len0to4(const char *s, size_t len) {
     b = b * c1 + v;
     c ^= b;
   }
-  return fmix(Mur(b, Mur(len, c)));
+  return fmix(Mur(b, Mur((uint32_t)len, c)));
 }
 
 static uint32_t Hash32Len5to12(const char *s, size_t len) {
-  uint32_t a = len, b = len * 5, c = 9, d = b;
+  uint32_t a = (uint32_t)len, b = (uint32_t)(len * 5), c = 9, d = b;
   a += Fetch32(s);
   b += Fetch32(s + len - 4);
   c += Fetch32(s + ((len >> 1) & 4));
@@ -129,7 +129,7 @@ uint32_t CityHash32(const char *s, size_t len) {
   }
 
   // len > 24
-  uint32_t h = len, g = c1 * len, f = g;
+  uint32_t h = (uint32_t)len, g = (uint32_t)(c1 * len), f = g;
 
   uint32_t a0 = Rotate32(Fetch32(s + len - 4) * c1, 17) * c2;
   uint32_t a1 = Rotate32(Fetch32(s + len - 8) * c1, 17) * c2;
@@ -234,7 +234,7 @@ static uint64_t HashLen0to16(const char *s, size_t len) {
     uint8_t b = s[len >> 1];
     uint8_t c = s[len - 1];
     uint32_t y = static_cast<uint32_t>(a) + (static_cast<uint32_t>(b) << 8);
-    uint32_t z = len + (static_cast<uint32_t>(c) << 2);
+    uint32_t z = (uint32_t)(len + (static_cast<uint32_t>(c) << 2));
     return ShiftMix(y * k2 ^ z * k0) * k2;
   }
   return k2;

--- a/absl/random/internal/pcg_engine.h
+++ b/absl/random/internal/pcg_engine.h
@@ -262,7 +262,7 @@ struct pcg_xsl_rr_128_64 {
     uint64_t rotate = h >> 58u;
     uint64_t s = Uint128Low64(state) ^ h;
 #endif
-    return rotr(s, rotate);
+    return rotr(s, (int)rotate);
   }
 };
 

--- a/absl/random/internal/seed_material.cc
+++ b/absl/random/internal/seed_material.cc
@@ -173,7 +173,7 @@ bool ReadSeedMaterialFromDevURandom(absl::Span<uint32_t> values) {
   }
 
   while (success && buffer_size > 0) {
-    int bytes_read = read(dev_urandom, buffer, buffer_size);
+    int bytes_read = (int)read(dev_urandom, buffer, buffer_size);
     int read_error = errno;
     success = (bytes_read > 0);
     if (success) {

--- a/absl/status/status.cc
+++ b/absl/status/status.cc
@@ -79,7 +79,7 @@ static int FindPayloadIndexByUrl(const Payloads* payloads,
   if (payloads == nullptr) return -1;
 
   for (size_t i = 0; i < payloads->size(); ++i) {
-    if ((*payloads)[i].type_url == type_url) return i;
+    if ((*payloads)[i].type_url == type_url) return (int)i;
   }
 
   return -1;

--- a/absl/strings/charconv.cc
+++ b/absl/strings/charconv.cc
@@ -337,7 +337,7 @@ void EncodeResult(const CalculatedFloat& calculated, bool negative,
     *value = negative ? -0.0 : 0.0;
     return;
   }
-  *value = FloatTraits<FloatType>::Make(calculated.mantissa,
+  *value = FloatTraits<FloatType>::Make((uint32_t)(calculated.mantissa),
                                         calculated.exponent, negative);
 }
 

--- a/absl/strings/internal/str_format/float_conversion.cc
+++ b/absl/strings/internal/str_format/float_conversion.cc
@@ -465,7 +465,7 @@ Padding ExtraWidthToPadding(size_t total_size, const FormatState &state) {
       static_cast<size_t>(state.conv.width()) <= total_size) {
     return {0, 0, 0};
   }
-  int missing_chars = state.conv.width() - total_size;
+  int missing_chars = (int)(state.conv.width() - total_size);
   if (state.conv.has_left_flag()) {
     return {0, 0, missing_chars};
   } else if (state.conv.has_zero_flag()) {
@@ -1263,7 +1263,7 @@ bool FloatToBuffer(Decomposed<Float> decomposed, int precision, Buffer *out,
   if (CanFitMantissa<Float, std::uint64_t>() &&
       FloatToBufferImpl<std::uint64_t, Float, mode>(
           static_cast<std::uint64_t>(decomposed.mantissa),
-          static_cast<std::uint64_t>(decomposed.exponent), precision, out, exp))
+          static_cast<int>(decomposed.exponent), precision, out, exp))
     return true;
 
 #if defined(ABSL_HAVE_INTRINSIC_INT128)

--- a/absl/time/format.cc
+++ b/absl/time/format.cc
@@ -64,7 +64,7 @@ cctz_parts Split(absl::Time t) {
 // details about rep_hi and rep_lo.
 absl::Time Join(const cctz_parts& parts) {
   const int64_t rep_hi = (parts.sec - unix_epoch()).count();
-  const uint32_t rep_lo = parts.fem.count() / (1000 * 1000 / 4);
+  const uint32_t rep_lo = (uint32_t)(parts.fem.count() / (1000 * 1000 / 4));
   const auto d = time_internal::MakeDuration(rep_hi, rep_lo);
   return time_internal::FromUnixDuration(d);
 }


### PR DESCRIPTION
This patch fixed 32bit conversion warning (-Wshorten-64-to-32) as seem from default SPM bulds in downstream projects 
 - Upstream fix coming later from abseil cpp repo 

### Build and Test Verification

```bash
swift build --target abseil
swift test
```

----
cc @paulb777  @wu-hui