### PR TITLE
Add test for duplicate entrypoints

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -20,4 +20,4 @@ jobs:
     - name: tvOS Build Tests
       run: xcodebuild -scheme abseil build -sdk "appletvsimulator" -destination 'platform=tvOS Simulator,name=Apple TV'
     - name: iOS Device Build Tests
-      run: xcodebuild -scheme abseil build -sdk 'iphoneos'      
+      run: xcodebuild -scheme abseil build -sdk 'iphoneos' -destination 'generic/platform=iOS'

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // main functions
         "absl/hash/internal/print_hash_of.cc",
         "absl/random/internal/gaussian_distribution_gentables.cc",
-        "absl/random/internal/randen_benchmarks.cc",
+        // "absl/random/internal/randen_benchmarks.cc",
       ],
       sources: [
         "absl/"

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // main functions
         "absl/hash/internal/print_hash_of.cc",
         "absl/random/internal/gaussian_distribution_gentables.cc",
-        // "absl/random/internal/randen_benchmarks.cc",
+        "absl/random/internal/randen_benchmarks.cc",
       ],
       sources: [
         "absl/"

--- a/SwiftPMTests/build-test/test.cc
+++ b/SwiftPMTests/build-test/test.cc
@@ -46,3 +46,6 @@
 #include "absl/types/any.h"
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"
+
+// Test for duplicate `_main` symbol.
+int main(int argc, char** argv) {}


### PR DESCRIPTION
Add a main function to spm tests to test that the package doesn't include any other entrypoints, which would cause duplicate symbol errors when including abseil in an app.

See failing test from including benchmark file with a "main" function: https://github.com/firebase/abseil-cpp-SwiftPM/actions/runs/3868703055/jobs/6594320455#step:4:714