### PR TITLE
exclude a test file with main function

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
       path: ".",
       exclude: [
         // main functions
+        "absl/base/c_header_test.c",
         "absl/hash/internal/print_hash_of.cc",
         "absl/random/internal/gaussian_distribution_gentables.cc",
         "absl/random/internal/randen_benchmarks.cc",


### PR DESCRIPTION
This is a new test file that doesn't follow the filename pattern (*_test.cc) when deleting test files in https://github.com/firebase/abseil-cpp-SwiftPM/pull/23.
This PR add it to exclude file to avoid the `::duplicate symbol '_main'` error in https://github.com/firebase/firebase-ios-sdk/pull/14342

There is an [existing test](https://github.com/firebase/abseil-cpp-SwiftPM/blob/0.20240722.1/SwiftPMTests/build-test/test.cc#L51) that's supposed to capture such issue but not sure why it didn't work.
