### PR TITLE
[Infra] Use Xcode 16.4 in spm.yml

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Simulator Build Tests
-      run: xcodebuild -scheme abseil build -sdk 'iphonesimulator' -destination 'platform=iOS Simulator,name=iPhone 11'
+      run: xcodebuild -scheme abseil build -sdk 'iphonesimulator' -destination 'platform=iOS Simulator,name=iPhone 16'
     - name: macos Build Tests
       run: xcodebuild -scheme abseil build -sdk 'macosx' -destination 'platform=OS X,arch=x86_64',
     - name: tvOS Build Tests

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Set Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Simulator Build Tests


### PR DESCRIPTION
Reason for change: https://github.com/actions/runner-images/issues/12541 caused the removal of sims for default Xcode version on macOS 15 runner (Xcode 16). To fix, set Xcode to 16.4 to get sims.  